### PR TITLE
Update ruleset.xml

### DIFF
--- a/ITMH/ruleset.xml
+++ b/ITMH/ruleset.xml
@@ -83,10 +83,13 @@
 
         <!-- несколько значений в однострочном массиве -->
         <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed"/>
-        
+
+        <!-- массив с одним элементом на нескольких строчках -->
+        <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/>
+
         <!-- знак препинания в конце однострочного комментария -->
         <exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
-        
+
         <!-- пробел между : и ) в конструкции if (condition): -->
         <exclude name="PEAR.ControlStructures.MultilineCondition.SpaceBeforeOpenBrace"/>
     </rule>


### PR DESCRIPTION
Исключена инспекция проверяющая массив с одним элементом расположенным на нескольких строках.

Пример кода:

```
->orderBy([ //Срабатывает здесь
    new Expression(
        "FIELD(id, '" . implode('\', \'', $gwlist) . "')"
    )
])
```
